### PR TITLE
Use History redis module

### DIFF
--- a/mailfilter/rootfs/etc/rspamd/local.d/history_redis.conf
+++ b/mailfilter/rootfs/etc/rspamd/local.d/history_redis.conf
@@ -1,0 +1,5 @@
+servers = 127.0.0.1:6379; # Redis server to store history
+key_prefix = "rs_history"; # Default key name
+nrows = 300; # Default rows limit
+compress = true; # Use zstd compression when storing data in Redis
+subject_privacy = false; # subject privacy is off


### PR DESCRIPTION
# Proposed Changes

> Use Redis history module instead of legacy history

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
