### PR TITLE
Try Alpine 3.7.5

### DIFF
--- a/mailfilter/Dockerfile
+++ b/mailfilter/Dockerfile
@@ -25,8 +25,8 @@ RUN apk add --no-cache \
     clamav=1.2.1-r0 \
     clamav-libunrar=1.2.1-r0 \
     redis=7.2.3-r0 \
-    rspamd --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-    rspamd-openrc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+    rspamd --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+    rspamd-openrc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
     && mkdir -p /run/systemd/journal \
     && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/syslogd-overlay-noarch.tar.xz" \
         | tar -C / -Jxpf - 

--- a/mailfilter/Dockerfile
+++ b/mailfilter/Dockerfile
@@ -27,8 +27,9 @@ RUN apk add --no-cache \
     clamav=1.2.1-r0 \
     clamav-libunrar=1.2.1-r0 \
     redis=7.2.3-r0 \
-    rspamd@testing \
-    rspamd-openrc@testing \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+    rspamd --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+    rspamd-openrc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
     && mkdir -p /run/systemd/journal \
     && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/syslogd-overlay-noarch.tar.xz" \
         | tar -C / -Jxpf - 

--- a/mailfilter/Dockerfile
+++ b/mailfilter/Dockerfile
@@ -17,6 +17,8 @@ ARG S6_OVERLAY_VERSION="v3.1.6.2"
 
 # Setup base
 
+sed -i 's|v3\.\d*|edge|' /etc/apk/repositories
+
 RUN apk add --no-cache \
     nginx=1.24.0-r14 \
     freshclam=1.2.1-r0 \

--- a/mailfilter/Dockerfile
+++ b/mailfilter/Dockerfile
@@ -17,8 +17,6 @@ ARG S6_OVERLAY_VERSION="v3.1.6.2"
 
 # Setup base
 
-sed -i 's|v3\.\d*|edge|' /etc/apk/repositories
-
 RUN apk add --no-cache \
     nginx=1.24.0-r14 \
     freshclam=1.2.1-r0 \

--- a/mailfilter/Dockerfile
+++ b/mailfilter/Dockerfile
@@ -25,7 +25,6 @@ RUN apk add --no-cache \
     clamav=1.2.1-r0 \
     clamav-libunrar=1.2.1-r0 \
     redis=7.2.3-r0 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
     rspamd --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
     rspamd-openrc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
     && mkdir -p /run/systemd/journal \

--- a/mailfilter/Dockerfile
+++ b/mailfilter/Dockerfile
@@ -25,8 +25,8 @@ RUN apk add --no-cache \
     clamav=1.2.1-r0 \
     clamav-libunrar=1.2.1-r0 \
     redis=7.2.3-r0 \
-    rspamd=3.7.4-r0 \
-    rspamd-openrc=3.7.4-r0 \
+    rspamd@testing \
+    rspamd-openrc@testing \
     && mkdir -p /run/systemd/journal \
     && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/syslogd-overlay-noarch.tar.xz" \
         | tar -C / -Jxpf - 


### PR DESCRIPTION
# Proposed Changes
- Use Alpine 3.7.5 from Alpine Edge repository to fix hyperscan errors
> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
